### PR TITLE
NVRTC is now internal, cannot be required.

### DIFF
--- a/articles/getting_started.md
+++ b/articles/getting_started.md
@@ -17,7 +17,7 @@ ClojureCUDA uses native Nvidia GPU drivers, and CUDA toolkit, so it is very impo
 
 ## Usage
 
-First `use` or `require` `uncomplicate.clojurecuda.core` and/or `uncomplicate.clojurecuda.info` and/or `uncomplicate.clojurecuda.nvrtc`  in your namespace, and you'll be able to call appropriate functions from the ClojureCUDA library.
+First `use` or `require` `uncomplicate.clojurecuda.core` and/or `uncomplicate.clojurecuda.info` in your namespace, and you'll be able to call appropriate functions from the ClojureCUDA library.
 
 ```clojure
 (require '[uncomplicate.clojurecuda.core :refer :all]

--- a/articles/getting_started.md
+++ b/articles/getting_started.md
@@ -21,8 +21,7 @@ First `use` or `require` `uncomplicate.clojurecuda.core` and/or `uncomplicate.cl
 
 ```clojure
 (require '[uncomplicate.clojurecuda.core :refer :all]
-         '[uncomplicate.clojurecuda.info :refer :all]
-         '[uncomplicate.clojurecuda.nvrtc :refer :all])
+         '[uncomplicate.clojurecuda.info :refer :all])
 ```
 
 Now you can work with CUDA devices, contexts, streams, memory etc.


### PR DESCRIPTION
File Not Found Exception
Could not locate uncomplicate/clojurecuda/nvrtc__init.class or uncomplicate/clojurecuda/nvrtc.clj on classpath. clojure.lang.RT.load (RT.java:463)